### PR TITLE
fix asciidoc syntax for links

### DIFF
--- a/UI Designs.adoc
+++ b/UI Designs.adoc
@@ -7,10 +7,10 @@ Invision, please refer to: https://support.invisionapp.com/hc/en-us/articles/209
 
 
 == UI Designs Table of Content
-* [Create Gluster Cluster Workflow](https://redhat.invisionapp.com/share/8F8PQVLHD) - guided experience for creatig a Gluster cluster with a demo/data file share (aka volume) at the end of the workflow
-* [Import Gluster Cluster Workflow](https://redhat.invisionapp.com/share/R88EUSGJK) - import an existing Gluster cluster
-* [First Use Experience](https://redhat.invisionapp.com/share/6T900V2ZX) - Initial landing page and creation or import of a cluster
-* [List Views](https://redhat.invisionapp.com/share/BR8JDCGSQ) - UI for all top-level list views including Clusters, Hosts, Pools, RBDs, and File Shares
-* [Add File Share](https://redhat.invisionapp.com/share/Q78YMAVDJ) - guided experience for adding a Volume/File Share
-* [Tasks and Events](https://redhat.invisionapp.com/share/8N93NO7Q4) - Views for examining events, tasks, and notifications/alerts.
+* https://redhat.invisionapp.com/share/8F8PQVLHD[Create Gluster Cluster Workflow] - guided experience for creatig a Gluster cluster with a demo/data file share (aka volume) at the end of the workflow
+* https://redhat.invisionapp.com/share/R88EUSGJK[Import Gluster Cluster Workflow] - import an existing Gluster cluster
+* https://redhat.invisionapp.com/share/6T900V2ZX[First Use Experience] - Initial landing page and creation or import of a cluster
+* https://redhat.invisionapp.com/share/BR8JDCGSQ[List Views] - UI for all top-level list views including Clusters, Hosts, Pools, RBDs, and File Shares
+* https://redhat.invisionapp.com/share/Q78YMAVDJ[Add File Share] - guided experience for adding a Volume/File Share
+* https://redhat.invisionapp.com/share/8N93NO7Q4[Tasks and Events] - Views for examining events, tasks, and notifications/alerts.
 


### PR DESCRIPTION
Done via sed:

    sed -i 's!\[\(.*\)\](\([^()]*\))!\2[\1]!' UI\ Designs.adoc

following syntax as documented in:

http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#links