### PR TITLE
rename make target update-release to gitversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ srpm:   dist build-pkgs-dist
 rpm:    srpm
 	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm --resultdir=. --define "dist .el7"
 
-update-release:
+gitversion:
 	sed -i $(NAME).spec \
 	  -e "/^Release:/cRelease: $(shell date +"%Y%m%dT%H%M%S").$(SHORTCOMMIT)"
 
-snapshot: update-release srpm
+snapshot: gitversion srpm
 
-.PHONY: dist rpm srpm update-release snapshot
+.PHONY: dist rpm srpm gitversion snapshot


### PR DESCRIPTION
- unify `gitversion` target name across other Tendrl repos
- fix https://github.com/Tendrl/ui/issues/831
- related to https://github.com/Tendrl/tendrl-ci/pull/8
