### PR TITLE
Fixed: redundant UI text in the Unmanage cluster confirmation box

### DIFF
--- a/src/modules/clusters/unmanage-cluster/unmanage-progress/unmanage-progress.html
+++ b/src/modules/clusters/unmanage-cluster/unmanage-progress/unmanage-progress.html
@@ -6,7 +6,7 @@
                 <i class="pficon pficon pficon-ok"></i> 
             </div>
             <div class="col-md-10 desc">
-                Unmanage Cluster task Submitted An Unmanage Cluster task has been submitted to unmanage <strong>{{vm.clusterName}}</strong>. You will be notified when processing is complete.
+                An Unmanage cluster task is submitted to unmanage <strong>{{vm.clusterName}}</strong>. You will be notified when processing is complete.
             </div>
         </div>
         <custom-modal-footer modal-footer="vm.modalFooter"></custom-modal-footer>


### PR DESCRIPTION
Bugzilla: 1592464
tendrl-github-id: https://github.com/Tendrl/ui/issues/996

Signed-off-by: Neha Gupta <gnehapk@gmail.com>